### PR TITLE
Discord Embed Support & Raw Image path

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -30,6 +30,19 @@ interface Image {
 	filename: string;
 	type: string;
 	time: number;
+	embed?: {
+		title?: string;
+		description?: string;
+		author?: {
+			name?: string;
+			url?: string;
+		}
+		provider?: {
+			name?: string;
+			url?: string;
+		}
+		color?: string;
+	}
 }
 
 /**
@@ -152,6 +165,24 @@ app.post('/upload', bindingReadyMiddleware, async (ctx) => {
 			type: image.type,
 			time: Date.now()
 		};
+
+		// Extract embed data from Headers (if present)
+		const embed = ctx.req.headers.get('x-cheek-title') === '' ? undefined : {
+			title: ctx.req.headers.get('x-cheek-title'),
+			description: ctx.req.headers.get('x-cheek-description') || undefined,
+			author: {
+				name: ctx.req.headers.get('x-cheek-author-name') || undefined,
+				url: ctx.req.headers.get('x-cheek-author-url') || undefined
+			},
+			provider: {
+				name: ctx.req.headers.get('x-cheek-provider-name') || undefined,
+				url: ctx.req.headers.get('x-cheek-provider-url') || undefined
+			},
+			color: ctx.req.headers.get('x-cheek-color') || undefined
+		};
+
+		// Add embed data to metadata
+		if (embed) metadata.embed = embed;
 
 		// Save metadata to KV
 		await ctx.env.cheekkv.put(metadata.id, JSON.stringify(metadata));

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -1,0 +1,23 @@
+import { Image } from './app';
+
+const genHTML = (metadata: Image, URL: string) => {
+    console.log(URL);
+    return(
+    `
+    <!DOCTYPE HTML>
+    <html>
+    <head>
+    <meta property="og:title" content="${metadata.embed?.title}" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="${metadata.embed?.provider.url}" />
+    <meta property="og:description" content="${metadata.embed?.description}" />
+    <meta property="og:image" content="${URL}" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="theme-color" content="${metadata.embed?.color}" />
+    </head>
+    </html>
+    `
+    )
+}
+
+export default genHTML


### PR DESCRIPTION
It's shit, it works somehow.

I thought of making the /:id path same as ASS, aka a pretty thingy when you click it and /:id/raw for the actual image.
Then I made a scuffed af embed "support", it doesn't support all parameters said in the Image Interface, but it works ™️.

I couldn't figure out how to do the embed in Pug :(

LMK how it looks; GL-

_PS: shit this wasn't supposed to be from master my bad <3_